### PR TITLE
Check that 'add' in assertion functions is an AssertCollection

### DIFF
--- a/R/makeAssertion.R
+++ b/R/makeAssertion.R
@@ -39,6 +39,7 @@
 makeAssertion = function(x, res, var.name, collection) {
   if (!identical(res, TRUE)) {
     if (is.null(collection))
+      assertClass(collection, "AssertCollection", .var.name = "add")
       mstop("Assertion on '%s' failed: %s.", var.name, res)
     collection$push(sprintf("Variable '%s': %s.", var.name, res))
   }


### PR DESCRIPTION
Note the following example:

x <- 1
error_collection <- list()
assertCharacter(x, add = error_collection)

This PR introduces an extra check so that the following example returns an informative error.